### PR TITLE
Modifies the use of __slots__ for get_fields_and_field_types method

### DIFF
--- a/rclpy_message_converter/rclpy_message_converter/message_converter.py
+++ b/rclpy_message_converter/rclpy_message_converter/message_converter.py
@@ -213,8 +213,11 @@ def message_to_ordereddict(
     """
     d = OrderedDict()
 
-    # We rely on __slots__ retaining the order of the fields in the .msg file.
-    for field_name, field_type in zip(msg.__slots__, msg.SLOT_TYPES):
+    # The get_fields_and_field_types() method returns a map of field_names to stringified versions
+    # of the field types. But here we want the "rosidl_parser.definition" types, so we zip the
+    # field names together with SLOT_TYPES. The length of these two is guaranteed to be the same
+    # length by the Python code generator.
+    for field_name, field_type in zip(msg.get_fields_and_field_types().keys(), msg.SLOT_TYPES):
         value = getattr(msg, field_name, None)
 
         value = _convert_value(
@@ -339,9 +342,8 @@ def __get_type_name(value_type):
 
 
 def _get_message_fields(message):
-    # Workaround due to new python API https://github.com/ros2/rosidl_python/issues/99
-    slots = [slot[1:] for slot in message.__slots__]  # remove leading underscore
-    return zip(slots, message.SLOT_TYPES)
+    field_names = [field_name for field_name in message.get_fields_and_field_types().keys()]
+    return zip(field_names, message.SLOT_TYPES)
 
 
 if __name__ == "__main__":

--- a/rclpy_message_converter/rclpy_message_converter/message_converter.py
+++ b/rclpy_message_converter/rclpy_message_converter/message_converter.py
@@ -228,8 +228,7 @@ def message_to_ordereddict(
             no_arr=no_arr,
             no_str=no_str,
         )
-        # Remove leading underscore from field name
-        d[field_name[1:]] = value
+        d[field_name] = value
     return d
 
 


### PR DESCRIPTION
## Summary
The attribute `__slots__` from a message represents all the attributes from the python class for that message, not only the field names of each component from the message structure. So far, this shouldn't impose any issue, however, taking into account the upcoming modifications from [this PR](https://github.com/ros2/rosidl_python/pull/194) in the `rosidl_python` package, the current use of the attribute in the `message_converter.py` file would be affected and therefore, break something. 

This PR solves that issue by modifying the use of `__slots__` for the appropriate method to retrieve the field names and types `get_fields_and_field_types()`.